### PR TITLE
Add initial bosh release packages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,15 @@
+cflinuxfs4-release
+
+Copyright (c) 2013-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# cflinuxfs4-compat-release
+### cflinuxfs4-compat BOSH Release
+
+This repository is a [BOSH](https://github.com/cloudfoundry/bosh) release for
+deploying the cflinuxfs4 rootfs (with the addition of ruby, python, and associated packages)
+package as well as a job that will extract the package to
+`/var/vcap/packages/cflinuxfs4-compat/rootfs`.
+
+#### Trusted certificates
+
+Trusted certs can be installed in the rootfs by setting the
+`cflinuxfs4-compat-rootfs.trusted_certs` property to the certificate chain in any
+order. For example in your deployment manifest:
+
+```
+properties:
+  cflinuxfs4-compat-rootfs:
+    trusted_certs: |+
+      -----BEGIN CERTIFICATE-----
+      MIIDQjCCAiqgAwIBAgIJAP/z/IO9Vh6HMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+      BAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX
+      aWRnaXRzIFB0eSBMdGQwIBcNMTYwMzAxMTg0NzQ3WhgPMjI4OTEyMTQxODQ3NDda
+      MEwxCzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxDTE9VREZPVU5EUlkxJjAkBgNVBAMT
+      HWJsb2JzdG9yZS5zZXJ2aWNlLmNmLmludGVybmFsMIIBIjANBgkqhkiG9w0BAQEF
+      AAOCAQ8AMIIBCgKCAQEAmcQD0ryug94fllXGM9+mpfHTrT++ZTGZpZ0KCde0iky7
+      fprXiVIoHMqgCDnPvSmI7AUZ0TIxYZtm9FfIkdtjk0QW8PbXmbxEBQwH75EgPqNS
+      0rkkmwzvVlPI963CTyR0SNpjK8s5GpGO9PQd/OY2AQG1ty1jE1T0YLGdaI2LWsHq
+      Y11WFkPYdOfYVnSZeiJkvOkZdZ5KQjZLfgMtyg3cV7yIA552OQiQn3OAFl15K0Bg
+      XTjHWfgu5vVGDr/dw0/Dlm2M56EIRBvc/XBJ9/+cj++R3ru77EfJF/h5vn1ahSxZ
+      RLWOmDoEOhfDmZ9w/QNWFpHWGJ9dHH7wLN8W/naUkwIDAQABoywwKjAoBgNVHREE
+      ITAfgh1ibG9ic3RvcmUuc2VydmljZS5jZi5pbnRlcm5hbDANBgkqhkiG9w0BAQUF
+      AAOCAQEABHHiEQW+lG2kM987QeRkycXAwASUtZJV8wrbB8PUn9BC799TVXGkpFLr
+      oflUnw4hxAlnwrSYWX+1ueCJ2cR1HoXUMTrwK4a5GUtoHnKJQwnb8K+z7lC+0oqE
+      GX+CTb7pPjxwHKGgRw1jjRNLaf3wxnSMrS73OcikF5aGcHylxdCDhAMDvcX6xuqP
+      kDMh20Kjg5brpRhZdkBIe9Tja8W4MZfugzZrPamvo14mRinZVnpiXodvhGHxkHvZ
+      /SA6HwVuqxoYEC+lqJkLbSqyVPSxLvidKl1Zb6074AZxmVlipmrnEETLaScE98Fp
+      XqP9Bw730tiw8W3mZ3NFDQtwAowlqw==
+      -----END CERTIFICATE-----
+```
+
+
+#### Running smoke tests
+
+1. Target your bosh director
+
+1. Run `bosh -n deploy -d rootfs-smoke-test manifests/manifest.yml && bosh run-errand -d rootfs-smoke-test cflinuxfs4-compat-smoke-test`
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ package as well as a job that will extract the package to
 #### Trusted certificates
 
 Trusted certs can be installed in the rootfs by setting the
-`cflinuxfs4-compat-rootfs.trusted_certs` property to the certificate chain in any
+`cflinuxfs4-rootfs.trusted_certs` property to the certificate chain in any
 order. For example in your deployment manifest:
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ order. For example in your deployment manifest:
 
 ```
 properties:
-  cflinuxfs4-compat-rootfs:
+  cflinuxfs4-rootfs:
     trusted_certs: |+
       -----BEGIN CERTIFICATE-----
       MIIDQjCCAiqgAwIBAgIJAP/z/IO9Vh6HMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV

--- a/config/final.yml
+++ b/config/final.yml
@@ -1,0 +1,6 @@
+---
+final_name: cflinuxfs4-compat
+blobstore:
+  provider: s3
+  options:
+    bucket_name: rootfs

--- a/jobs/cflinuxfs4-rootfs-setup/spec
+++ b/jobs/cflinuxfs4-rootfs-setup/spec
@@ -1,0 +1,21 @@
+---
+name: cflinuxfs4-compat-rootfs-setup
+
+templates:
+  pre-start: bin/pre-start
+  trusted_ca.crt.erb: config/certs/trusted_ca.crt
+
+packages:
+  - cflinuxfs4-compat
+  - rootfs-certsplitter-cflinuxfs4-compat
+
+properties:
+  cflinuxfs4-compat-rootfs.trusted_certs:
+    description: "Array or concatenation of PEM-encoded CA certficates to add to the rootfs trust store."
+    example: |
+      -----BEGIN CERTIFICATE-----
+      (contents of certificate #1)
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      (contents of certificate #2)
+      -----END CERTIFICATE-----

--- a/jobs/cflinuxfs4-rootfs-setup/spec
+++ b/jobs/cflinuxfs4-rootfs-setup/spec
@@ -1,16 +1,16 @@
 ---
-name: cflinuxfs4-compat-rootfs-setup
+name: cflinuxfs4-rootfs-setup
 
 templates:
   pre-start: bin/pre-start
   trusted_ca.crt.erb: config/certs/trusted_ca.crt
 
 packages:
-  - cflinuxfs4-compat
-  - rootfs-certsplitter-cflinuxfs4-compat
+  - cflinuxfs4
+  - rootfs-certsplitter-cflinuxfs4
 
 properties:
-  cflinuxfs4-compat-rootfs.trusted_certs:
+  cflinuxfs4-rootfs.trusted_certs:
     description: "Array or concatenation of PEM-encoded CA certficates to add to the rootfs trust store."
     example: |
       -----BEGIN CERTIFICATE-----

--- a/jobs/cflinuxfs4-rootfs-setup/templates/pre-start
+++ b/jobs/cflinuxfs4-rootfs-setup/templates/pre-start
@@ -1,0 +1,50 @@
+#!/bin/bash -ex
+# vim: set ft=sh
+
+CONF_DIR=/var/vcap/jobs/cflinuxfs4-compat-rootfs-setup/config
+ROOTFS_PACKAGE=/var/vcap/packages/cflinuxfs4-compat
+ROOTFS_DIR=$ROOTFS_PACKAGE/rootfs
+ROOTFS_TAR=$ROOTFS_PACKAGE/rootfs.tar
+TRUSTED_CERT_FILE=$CONF_DIR/certs/trusted_ca.crt
+CA_DIR=$ROOTFS_DIR/usr/local/share/ca-certificates/
+
+if [ ! -d $ROOTFS_DIR ]; then
+  mkdir -p $ROOTFS_DIR
+  tar -pzxf $ROOTFS_PACKAGE/cflinuxfs4-compat.tar.gz -C $ROOTFS_DIR
+fi
+
+if grep -q "trusted_ca_certificates" $TRUSTED_CERT_FILE; then
+  JSON_CERT_FILE=$CONF_DIR/certs/trusted_ca.json
+  cp $TRUSTED_CERT_FILE $JSON_CERT_FILE
+  TRUSTED_CERT_FILE=$JSON_CERT_FILE
+fi
+
+rm -f $ROOTFS_DIR/usr/local/share/ca-certificates/*
+mkdir -p $CA_DIR
+/var/vcap/packages/rootfs-certsplitter-cflinuxfs4-compat/bin/certsplitter $TRUSTED_CERT_FILE $CA_DIR
+chmod 0644 $CA_DIR/*
+
+# have to set TMPDIR so we can mktemp inside the chrooted subshell
+updated_certs=1
+retry_count=0
+max_retry_count=3
+
+set +e
+until [ $updated_certs -eq 0 ] || [ $retry_count -ge $max_retry_count ]; do
+  echo "trying to run update-ca-certificates..."
+  TMPDIR=/tmp timeout --signal=KILL 60s chroot $ROOTFS_DIR /usr/sbin/update-ca-certificates -f
+  updated_certs=$?
+  retry_count=$((retry_count + 1))
+done
+set -e
+
+if [ $updated_certs -ne 0 ]; then
+  echo "failed to setup ca certificates"
+  exit 1
+fi
+
+# change modification time to invalidate garden's image cache
+touch $ROOTFS_DIR
+
+tar -C $ROOTFS_DIR -cf $ROOTFS_TAR .
+rm -rf $ROOTFS_DIR

--- a/jobs/cflinuxfs4-rootfs-setup/templates/pre-start
+++ b/jobs/cflinuxfs4-rootfs-setup/templates/pre-start
@@ -1,8 +1,8 @@
 #!/bin/bash -ex
 # vim: set ft=sh
 
-CONF_DIR=/var/vcap/jobs/cflinuxfs4-compat-rootfs-setup/config
-ROOTFS_PACKAGE=/var/vcap/packages/cflinuxfs4-compat
+CONF_DIR=/var/vcap/jobs/cflinuxfs4-rootfs-setup/config
+ROOTFS_PACKAGE=/var/vcap/packages/cflinuxfs4
 ROOTFS_DIR=$ROOTFS_PACKAGE/rootfs
 ROOTFS_TAR=$ROOTFS_PACKAGE/rootfs.tar
 TRUSTED_CERT_FILE=$CONF_DIR/certs/trusted_ca.crt
@@ -10,7 +10,7 @@ CA_DIR=$ROOTFS_DIR/usr/local/share/ca-certificates/
 
 if [ ! -d $ROOTFS_DIR ]; then
   mkdir -p $ROOTFS_DIR
-  tar -pzxf $ROOTFS_PACKAGE/cflinuxfs4-compat.tar.gz -C $ROOTFS_DIR
+  tar -pzxf $ROOTFS_PACKAGE/cflinuxfs4.tar.gz -C $ROOTFS_DIR
 fi
 
 if grep -q "trusted_ca_certificates" $TRUSTED_CERT_FILE; then
@@ -21,7 +21,7 @@ fi
 
 rm -f $ROOTFS_DIR/usr/local/share/ca-certificates/*
 mkdir -p $CA_DIR
-/var/vcap/packages/rootfs-certsplitter-cflinuxfs4-compat/bin/certsplitter $TRUSTED_CERT_FILE $CA_DIR
+/var/vcap/packages/rootfs-certsplitter-cflinuxfs4/bin/certsplitter $TRUSTED_CERT_FILE $CA_DIR
 chmod 0644 $CA_DIR/*
 
 # have to set TMPDIR so we can mktemp inside the chrooted subshell

--- a/jobs/cflinuxfs4-rootfs-setup/templates/trusted_ca.crt.erb
+++ b/jobs/cflinuxfs4-rootfs-setup/templates/trusted_ca.crt.erb
@@ -1,0 +1,15 @@
+<%=
+cert_string = ""
+
+if_p("cflinuxfs4-compat-rootfs.trusted_certs") do |value|
+  if value.kind_of?(Array)
+    cert_string = { trusted_ca_certificates: value }.to_json
+  elsif value.kind_of?(String)
+    cert_string = value
+  else
+    raise("The 'cflinuxfs4-compat-rootfs.trusted_certs' property must be a string or an array")
+  end
+end
+
+cert_string
+%>

--- a/jobs/cflinuxfs4-rootfs-setup/templates/trusted_ca.crt.erb
+++ b/jobs/cflinuxfs4-rootfs-setup/templates/trusted_ca.crt.erb
@@ -1,13 +1,13 @@
 <%=
 cert_string = ""
 
-if_p("cflinuxfs4-compat-rootfs.trusted_certs") do |value|
+if_p("cflinuxfs4-rootfs.trusted_certs") do |value|
   if value.kind_of?(Array)
     cert_string = { trusted_ca_certificates: value }.to_json
   elsif value.kind_of?(String)
     cert_string = value
   else
-    raise("The 'cflinuxfs4-compat-rootfs.trusted_certs' property must be a string or an array")
+    raise("The 'cflinuxfs4-rootfs.trusted_certs' property must be a string or an array")
   end
 end
 

--- a/jobs/cflinuxfs4-smoke-test/spec
+++ b/jobs/cflinuxfs4-smoke-test/spec
@@ -1,0 +1,17 @@
+---
+name: cflinuxfs4-compat-smoke-test
+
+templates:
+  run.erb: bin/run
+  trusted_ca.crt.erb: config/certs/trusted_ca.crt
+
+properties:
+  cflinuxfs4-compat-rootfs.trusted_certs:
+    description: "Concatenation of PEM-encoded CA certficates to add to the rootfs trust store."
+    example: |
+      -----BEGIN CERTIFICATE-----
+      (contents of certificate #1)
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      (contents of certificate #2)
+      -----END CERTIFICATE-----

--- a/jobs/cflinuxfs4-smoke-test/spec
+++ b/jobs/cflinuxfs4-smoke-test/spec
@@ -1,12 +1,12 @@
 ---
-name: cflinuxfs4-compat-smoke-test
+name: cflinuxfs4-smoke-test
 
 templates:
   run.erb: bin/run
   trusted_ca.crt.erb: config/certs/trusted_ca.crt
 
 properties:
-  cflinuxfs4-compat-rootfs.trusted_certs:
+  cflinuxfs4-rootfs.trusted_certs:
     description: "Concatenation of PEM-encoded CA certficates to add to the rootfs trust store."
     example: |
       -----BEGIN CERTIFICATE-----

--- a/jobs/cflinuxfs4-smoke-test/templates/run.erb
+++ b/jobs/cflinuxfs4-smoke-test/templates/run.erb
@@ -2,10 +2,10 @@
 
 set -ex
 
-CERTS_PROPERTY=$(cat /var/vcap/jobs/cflinuxfs4-compat-smoke-test/config/certs/trusted_ca.crt)
+CERTS_PROPERTY=$(cat /var/vcap/jobs/cflinuxfs4-smoke-test/config/certs/trusted_ca.crt)
 CERTS_PROPERTY_COUNT=$(echo $CERTS_PROPERTY | grep "BEGIN CERTIFICATE" | wc -l)
 
-ROOTFS_TAR=/var/vcap/packages/cflinuxfs4-compat/rootfs.tar
+ROOTFS_TAR=/var/vcap/packages/cflinuxfs4/rootfs.tar
 ROOTFS_TMP=/tmp/rootfs
 mkdir -p "$ROOTFS_TMP"
 tar -C "$ROOTFS_TMP" -xf "$ROOTFS_TAR" .

--- a/jobs/cflinuxfs4-smoke-test/templates/run.erb
+++ b/jobs/cflinuxfs4-smoke-test/templates/run.erb
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -ex
+
+CERTS_PROPERTY=$(cat /var/vcap/jobs/cflinuxfs4-compat-smoke-test/config/certs/trusted_ca.crt)
+CERTS_PROPERTY_COUNT=$(echo $CERTS_PROPERTY | grep "BEGIN CERTIFICATE" | wc -l)
+
+ROOTFS_TAR=/var/vcap/packages/cflinuxfs4-compat/rootfs.tar
+ROOTFS_TMP=/tmp/rootfs
+mkdir -p "$ROOTFS_TMP"
+tar -C "$ROOTFS_TMP" -xf "$ROOTFS_TAR" .
+
+ROOTFS_CERTS_DIR="$ROOTFS_TMP/usr/local/share/ca-certificates/"
+SETUP_CERTS_COUNT=`find "$ROOTFS_CERTS_DIR" -type f | wc -l`
+
+if [[ "$CERTS_PROPERTY_COUNT" -ne "$SETUP_CERTS_COUNT" ]]; then
+  echo "certs in tar do not match spec property"
+  exit 1
+fi
+
+set +e
+stat -c "%a" "$ROOTFS_TMP"/usr/local/share/ca-certificates/* | grep -v 644
+if [[ "$?" == 0 ]]; then
+  echo "bad cert permissions"
+  exit 1
+fi
+set -e

--- a/jobs/cflinuxfs4-smoke-test/templates/trusted_ca.crt.erb
+++ b/jobs/cflinuxfs4-smoke-test/templates/trusted_ca.crt.erb
@@ -1,1 +1,1 @@
-<%=p("cflinuxfs4-compat-rootfs.trusted_certs").to_s %>
+<%=p("cflinuxfs4-rootfs.trusted_certs").to_s %>

--- a/jobs/cflinuxfs4-smoke-test/templates/trusted_ca.crt.erb
+++ b/jobs/cflinuxfs4-smoke-test/templates/trusted_ca.crt.erb
@@ -1,0 +1,1 @@
+<%=p("cflinuxfs4-compat-rootfs.trusted_certs").to_s %>

--- a/manifests/manifest.yml
+++ b/manifests/manifest.yml
@@ -6,7 +6,7 @@ update:
   max_in_flight: 1
   update_watch_time: 5000-120000
 instance_groups:
-  - name: cflinuxfs4-compat-smoke-test
+  - name: cflinuxfs4-smoke-test
     lifecycle: errand
     azs: [z1]
     instances: 1
@@ -17,10 +17,10 @@ instance_groups:
     networks:
     - name: default
     jobs:
-    - name: cflinuxfs4-compat-smoke-test
+    - name: cflinuxfs4-smoke-test
       release: cflinuxfs4-compat
       properties:
-        cflinuxfs4-compat-rootfs:
+        cflinuxfs4-rootfs:
           trusted_certs: |+
             -----BEGIN CERTIFICATE-----
             MIIFATCCAuugAwIBAgIBATALBgkqhkiG9w0BAQswEjEQMA4GA1UEAxMHZGllZ29D
@@ -51,10 +51,10 @@ instance_groups:
             r5EejEQP82achV3em5+macfNfEIILruStanw9D+kR1GYlE07wMTTmkZ39x3HMicf
             r4ERoMvnaSaiGVHIiCi9ZsoNLlf6TBNNfaqpc8jDZa2/o/nM+Q==
             -----END CERTIFICATE-----
-    - name: cflinuxfs4-compat-rootfs-setup
+    - name: cflinuxfs4-rootfs-setup
       release: cflinuxfs4-compat
       properties:
-        cflinuxfs4-compat-rootfs:
+        cflinuxfs4-rootfs:
           trusted_certs: |+
             -----BEGIN CERTIFICATE-----
             MIIFATCCAuugAwIBAgIBATALBgkqhkiG9w0BAQswEjEQMA4GA1UEAxMHZGllZ29D

--- a/manifests/manifest.yml
+++ b/manifests/manifest.yml
@@ -1,0 +1,94 @@
+---
+name: rootfs-smoke-test
+update:
+  canaries: 1
+  canary_watch_time: 5000-120000
+  max_in_flight: 1
+  update_watch_time: 5000-120000
+instance_groups:
+  - name: cflinuxfs4-compat-smoke-test
+    lifecycle: errand
+    azs: [z1]
+    instances: 1
+    vm_type: minimal
+    vm_extensions:
+    - 50GB_ephemeral_disk
+    stemcell: default
+    networks:
+    - name: default
+    jobs:
+    - name: cflinuxfs4-compat-smoke-test
+      release: cflinuxfs4-compat
+      properties:
+        cflinuxfs4-compat-rootfs:
+          trusted_certs: |+
+            -----BEGIN CERTIFICATE-----
+            MIIFATCCAuugAwIBAgIBATALBgkqhkiG9w0BAQswEjEQMA4GA1UEAxMHZGllZ29D
+            QTAeFw0xNTA3MTYxMzI0MTJaFw0yNTA3MTYxMzI0MTZaMBIxEDAOBgNVBAMTB2Rp
+            ZWdvQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCsrzEJ5hAQkdkT
+            l6z4ffiYvq4RSxKXkeZWTHv5b1w6FSnGCVoQL0ilKyQTGzn001TsZBhqJRmhKvLs
+            /4RC8a10KK8hmVhoV4MX690Abd47GbRQR6EPdcd4URHqr0NeeUIPviZGk1EYpFaM
+            T81eVq15Q+VrakVfGMjPIPfGqtXV14fs9jvkzVAdTysM8AtZtfwQC3ohVfkL7wA2
+            /Xs2YYQdLI1dKNnYdDxaDYmbjjCmxTMlkrloFBLmNveEEpy9Vnw3mcGyuAvq8PEr
+            Uua58czKsb81bONp7hzjK8I7BvpvneGTPXg7zzuVRRTwRhZSOoNcqE3/+EjJd5/W
+            ONtAYX66xN9apYGHcSmWDFxH6RBwLzJzJOo/FJ0AD5BkQBjJ4x5ZX+5X05oAegj1
+            wUYx32q2IrDIJzNF+CltrhY+bhJFmEqy72nomQPowSvuydlJMOYH5ATE8Lww0XzA
+            FmhityWvbmrgneSYdg9RvzbqLGTbuEBJ2D+X5WGtAlyvKRehoSJcOr0h9iRCnZIW
+            hu9YV6aBsVJHHyc1C4d4cpOx0U5QMXy05Z5wdSQra8n8pG7SC2K9V8HbOidr+4wI
+            ZWHwAIgyA0bVvHdGrGeeWeyW/XXD4YGyCAnT4DXWhTLPgxu4gg4rf7nnyHKcAqYp
+            DgHKMZOYTnbjCMcXyoYIJ8dR/RvYOQIDAQABo2YwZDAOBgNVHQ8BAf8EBAMCAAYw
+            EgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQUAU5pu7rUL87RDYhHRL+YYfgc
+            /4YwHwYDVR0jBBgwFoAUAU5pu7rUL87RDYhHRL+YYfgc/4YwCwYJKoZIhvcNAQEL
+            A4ICAQChLHQM6f769dt9L6MmjOLcYdmmMuyxY8iqdnJIa43MBxKjxzmt6xSIPMBU
+            BWFui5gScKPXiA9Nri2Tyzm5zjcQtoJUFcXA8RGgK4aVQ1QCuY4OyiR126WfZiiJ
+            J0btSmUXGIme25KEQ2PSiYmwPrLTFG3G+0ylUq6b/rPzHfkFOZXX4U9qLvqY9AnO
+            NuYxLT40xDwlL6drcvicEfZ+vV0SABf4HAH+wphRyHR4fkwOBrrieBXvpRUlGeRw
+            ZtDVeX8v28WZqoYXV/36JrGbhxSkqBXQk5gdrOUDXebaeQPRvarWCd2zSGmyADei
+            npMRDEovA7AlyxX//vBx9MKV3L3NhoL66nBgOwm23DZJLIwCM5AIBvyZMfMpB4sM
+            d2nUiXF+5WRFG1bjHuEmU0HvZGXFFzJaiJrnlvzDhJB32DQ5LgEeN+9X42x3DXUZ
+            +dR5Qqu0wgQGpdjC9sNsgMBcqVqmc8rWfRxHSusHff7tFs8gpzNRxH6Rimws9M0d
+            RFWLAS0T7YSB6deM41Efz7T4Gq+QLm7sv73pDhuIky+AZlWkAr9Wu/+RpNvcQfum
+            r5EejEQP82achV3em5+macfNfEIILruStanw9D+kR1GYlE07wMTTmkZ39x3HMicf
+            r4ERoMvnaSaiGVHIiCi9ZsoNLlf6TBNNfaqpc8jDZa2/o/nM+Q==
+            -----END CERTIFICATE-----
+    - name: cflinuxfs4-compat-rootfs-setup
+      release: cflinuxfs4-compat
+      properties:
+        cflinuxfs4-compat-rootfs:
+          trusted_certs: |+
+            -----BEGIN CERTIFICATE-----
+            MIIFATCCAuugAwIBAgIBATALBgkqhkiG9w0BAQswEjEQMA4GA1UEAxMHZGllZ29D
+            QTAeFw0xNTA3MTYxMzI0MTJaFw0yNTA3MTYxMzI0MTZaMBIxEDAOBgNVBAMTB2Rp
+            ZWdvQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCsrzEJ5hAQkdkT
+            l6z4ffiYvq4RSxKXkeZWTHv5b1w6FSnGCVoQL0ilKyQTGzn001TsZBhqJRmhKvLs
+            /4RC8a10KK8hmVhoV4MX690Abd47GbRQR6EPdcd4URHqr0NeeUIPviZGk1EYpFaM
+            T81eVq15Q+VrakVfGMjPIPfGqtXV14fs9jvkzVAdTysM8AtZtfwQC3ohVfkL7wA2
+            /Xs2YYQdLI1dKNnYdDxaDYmbjjCmxTMlkrloFBLmNveEEpy9Vnw3mcGyuAvq8PEr
+            Uua58czKsb81bONp7hzjK8I7BvpvneGTPXg7zzuVRRTwRhZSOoNcqE3/+EjJd5/W
+            ONtAYX66xN9apYGHcSmWDFxH6RBwLzJzJOo/FJ0AD5BkQBjJ4x5ZX+5X05oAegj1
+            wUYx32q2IrDIJzNF+CltrhY+bhJFmEqy72nomQPowSvuydlJMOYH5ATE8Lww0XzA
+            FmhityWvbmrgneSYdg9RvzbqLGTbuEBJ2D+X5WGtAlyvKRehoSJcOr0h9iRCnZIW
+            hu9YV6aBsVJHHyc1C4d4cpOx0U5QMXy05Z5wdSQra8n8pG7SC2K9V8HbOidr+4wI
+            ZWHwAIgyA0bVvHdGrGeeWeyW/XXD4YGyCAnT4DXWhTLPgxu4gg4rf7nnyHKcAqYp
+            DgHKMZOYTnbjCMcXyoYIJ8dR/RvYOQIDAQABo2YwZDAOBgNVHQ8BAf8EBAMCAAYw
+            EgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQUAU5pu7rUL87RDYhHRL+YYfgc
+            /4YwHwYDVR0jBBgwFoAUAU5pu7rUL87RDYhHRL+YYfgc/4YwCwYJKoZIhvcNAQEL
+            A4ICAQChLHQM6f769dt9L6MmjOLcYdmmMuyxY8iqdnJIa43MBxKjxzmt6xSIPMBU
+            BWFui5gScKPXiA9Nri2Tyzm5zjcQtoJUFcXA8RGgK4aVQ1QCuY4OyiR126WfZiiJ
+            J0btSmUXGIme25KEQ2PSiYmwPrLTFG3G+0ylUq6b/rPzHfkFOZXX4U9qLvqY9AnO
+            NuYxLT40xDwlL6drcvicEfZ+vV0SABf4HAH+wphRyHR4fkwOBrrieBXvpRUlGeRw
+            ZtDVeX8v28WZqoYXV/36JrGbhxSkqBXQk5gdrOUDXebaeQPRvarWCd2zSGmyADei
+            npMRDEovA7AlyxX//vBx9MKV3L3NhoL66nBgOwm23DZJLIwCM5AIBvyZMfMpB4sM
+            d2nUiXF+5WRFG1bjHuEmU0HvZGXFFzJaiJrnlvzDhJB32DQ5LgEeN+9X42x3DXUZ
+            +dR5Qqu0wgQGpdjC9sNsgMBcqVqmc8rWfRxHSusHff7tFs8gpzNRxH6Rimws9M0d
+            RFWLAS0T7YSB6deM41Efz7T4Gq+QLm7sv73pDhuIky+AZlWkAr9Wu/+RpNvcQfum
+            r5EejEQP82achV3em5+macfNfEIILruStanw9D+kR1GYlE07wMTTmkZ39x3HMicf
+            r4ERoMvnaSaiGVHIiCi9ZsoNLlf6TBNNfaqpc8jDZa2/o/nM+Q==
+            -----END CERTIFICATE-----
+releases:
+- name: cflinuxfs4-compat
+  version: latest
+stemcells:
+- alias: default
+  os: ubuntu-jammy
+  version: latest

--- a/packages/cflinuxfs4-compat/packaging
+++ b/packages/cflinuxfs4-compat/packaging
@@ -1,0 +1,4 @@
+set -e -x
+
+echo "Copying rootfs"
+cp rootfs/cflinuxfs4-compat-*.tar.gz ${BOSH_INSTALL_TARGET}/cflinuxfs4-compat.tar.gz

--- a/packages/cflinuxfs4-compat/packaging
+++ b/packages/cflinuxfs4-compat/packaging
@@ -1,4 +1,0 @@
-set -e -x
-
-echo "Copying rootfs"
-cp rootfs/cflinuxfs4-compat-*.tar.gz ${BOSH_INSTALL_TARGET}/cflinuxfs4-compat.tar.gz

--- a/packages/cflinuxfs4-compat/spec
+++ b/packages/cflinuxfs4-compat/spec
@@ -1,0 +1,4 @@
+---
+name: cflinuxfs4-compat
+files:
+- rootfs/cflinuxfs4-compat-*.tar.gz

--- a/packages/cflinuxfs4-compat/spec
+++ b/packages/cflinuxfs4-compat/spec
@@ -1,4 +1,0 @@
----
-name: cflinuxfs4-compat
-files:
-- rootfs/cflinuxfs4-compat-*.tar.gz

--- a/packages/cflinuxfs4/packaging
+++ b/packages/cflinuxfs4/packaging
@@ -1,0 +1,4 @@
+set -e -x
+
+echo "Copying rootfs"
+cp rootfs/cflinuxfs4-*.tar.gz ${BOSH_INSTALL_TARGET}/cflinuxfs4.tar.gz

--- a/packages/cflinuxfs4/spec
+++ b/packages/cflinuxfs4/spec
@@ -1,0 +1,4 @@
+---
+name: cflinuxfs4
+files:
+- rootfs/cflinuxfs4-*.tar.gz

--- a/packages/golang-1.18-linux/spec.lock
+++ b/packages/golang-1.18-linux/spec.lock
@@ -1,0 +1,2 @@
+name: golang-1.18-linux
+fingerprint: 5829bb5c8cccf961505ef1b39104c61ea6cb534b4dec31abc34d88ecd2174480

--- a/packages/rootfs-certsplitter/packaging
+++ b/packages/rootfs-certsplitter/packaging
@@ -14,7 +14,7 @@ pushd code.cloudfoundry.org/certsplitter
   go install -buildvcs=false code.cloudfoundry.org/certsplitter/cmd/certsplitter
 popd
 
-if [ ! -f "/var/vcap/packages/rootfs-certsplitter-cflinuxfs4-compat/bin/certsplitter" ]; then
+if [ ! -f "/var/vcap/packages/rootfs-certsplitter-cflinuxfs4/bin/certsplitter" ]; then
   echo "certsplitter install failed"
   exit 1
 fi

--- a/packages/rootfs-certsplitter/packaging
+++ b/packages/rootfs-certsplitter/packaging
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+
+source /var/vcap/packages/golang-1.18-linux/bosh/compile.env
+
+mkdir -p ${BOSH_INSTALL_TARGET}/src
+cp -a . ${BOSH_INSTALL_TARGET}/src
+export GOPATH=$BOSH_INSTALL_TARGET
+export GOBIN=$GOPATH/bin
+
+export GOROOT=$(readlink -nf /var/vcap/packages/golang-1.18-linux)
+export PATH=$GOROOT/bin:$PATH
+
+pushd code.cloudfoundry.org/certsplitter
+  go install -buildvcs=false code.cloudfoundry.org/certsplitter/cmd/certsplitter
+popd
+
+if [ ! -f "/var/vcap/packages/rootfs-certsplitter-cflinuxfs4-compat/bin/certsplitter" ]; then
+  echo "certsplitter install failed"
+  exit 1
+fi
+
+rm -rf ${BOSH_INSTALL_TARGET}/src ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/rootfs-certsplitter/spec
+++ b/packages/rootfs-certsplitter/spec
@@ -1,0 +1,8 @@
+---
+name: rootfs-certsplitter-cflinuxfs4-compat
+
+dependencies:
+  - golang-1.18-linux
+
+files:
+  - code.cloudfoundry.org/certsplitter/**/*

--- a/packages/rootfs-certsplitter/spec
+++ b/packages/rootfs-certsplitter/spec
@@ -1,5 +1,5 @@
 ---
-name: rootfs-certsplitter-cflinuxfs4-compat
+name: rootfs-certsplitter-cflinuxfs4
 
 dependencies:
   - golang-1.18-linux

--- a/releases/cflinuxfs4-compat/index.yml
+++ b/releases/cflinuxfs4-compat/index.yml
@@ -1,0 +1,2 @@
+builds:
+format-version: "2"


### PR DESCRIPTION
Files copied from https://github.com/cloudfoundry/cflinuxfs4-release and modified to reference `cflinuxfs4-compat` instead of `cflinuxfs4`. Part of https://github.com/cloudfoundry/cflinuxfs4-compat-release/issues/1