### PR TITLE
Use commit action from branch to allow multiple files in pathspec

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Git commit blobs.yml
       id: commit-1
-      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@pathspec-fix
       with:
         message: "Updating blobs for cflinuxfs4-compat bosh release version ${{ steps.repo-dispatch.outputs.version }}"
         pathspec: "config/blobs.yml"
@@ -75,7 +75,7 @@ jobs:
 
     - name: Git commit
       id: commit-2
-      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@pathspec-fix
       with:
         message: "Final cflinuxfs4-compat bosh release version ${{ steps.repo-dispatch.outputs.version }}, containing cflinuxfs-compat version ${{ steps.repo-dispatch.outputs.version }}"
         pathspec: .final_builds releases/**/*-${{ steps.repo-dispatch.outputs.version }}.yml releases/**/index.yml


### PR DESCRIPTION
Use action from pathspec-fix branch which does not quote items in the pathspec for `git add`. This should allow us to stage multiple files as we are doing in the `id: commit-2` step, and not affect situations where we add a single file like in `id: commit-1` step.

If this works, I will open a PR to github-config to have this change added to `main`