### PR TITLE
add separate commits for each changed file

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Git commit blobs.yml
       id: commit-1
-      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@pathspec-fix
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
       with:
         message: "Updating blobs for cflinuxfs4-compat bosh release version ${{ steps.repo-dispatch.outputs.version }}"
         pathspec: "config/blobs.yml"
@@ -73,9 +73,16 @@ jobs:
         keyid: ${{ secrets.CF_BOT_GPG_SIGNING_KEY_ID }}
         key: ${{ secrets.CF_BOT_GPG_SIGNING_KEY }}
 
+    - name: Git add release files
+      # manually git add files since there is a bug with multiple-file pathspec in the create-commit action
+      id: git-add
+      run: |
+        git add .final_builds releases/**/*-${{ steps.repo-dispatch.outputs.version }}.yml releases/**/index.yml
+        git status
+
     - name: Git commit
       id: commit-2
-      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@pathspec-fix
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
       with:
         message: "Final cflinuxfs4-compat bosh release version ${{ steps.repo-dispatch.outputs.version }}, containing cflinuxfs-compat version ${{ steps.repo-dispatch.outputs.version }}"
         pathspec: .final_builds releases/**/*-${{ steps.repo-dispatch.outputs.version }}.yml releases/**/index.yml


### PR DESCRIPTION
The create-commit action won't work with multiple filepaths int he `pathspec` field, so we have a separate step to do the git add for now. We will investigate the bug later.