### PR TITLE
create-release: wait for upstream image

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,6 +30,18 @@ jobs:
         fi
         echo "version=${version}" >> "$GITHUB_OUTPUT"
 
+    - name: Wait for rootfs docker image
+      run: |
+        until eval "$(
+          skopeo list-tags docker://cloudfoundry/cflinuxfs4 \
+            | jq -r \
+            --arg VERSION "${{ steps.repo-dispatch.outputs.version }}" \
+            '.Tags| any(. == $VERSION)')" ; do
+          echo "Waiting 30s for docker://cloudfoundry/cflinuxfs4:${{ steps.repo-dispatch.outputs.version }} to be available"
+          sleep 30
+        done
+        echo "image docker://cloudfoundry/cflinuxfs4:${{ steps.repo-dispatch.outputs.version }} is available"
+
     - name: Checkout cflinuxfs4
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
The cflinuxfs4 pipeline[1] takes a couple of mins after the github release for the docker image to be available. Wait until then before using it to build the compat stack.

1: https://buildpacks.ci.cf-app.com/teams/core-deps/pipelines/cflinuxfs4