### PR TITLE
ping issue: preserve xattr info #20

### DIFF
--- a/jobs/cflinuxfs4-rootfs-setup/templates/pre-start
+++ b/jobs/cflinuxfs4-rootfs-setup/templates/pre-start
@@ -10,7 +10,7 @@ CA_DIR=$ROOTFS_DIR/usr/local/share/ca-certificates/
 
 if [ ! -d $ROOTFS_DIR ]; then
   mkdir -p $ROOTFS_DIR
-  tar -pzxf $ROOTFS_PACKAGE/cflinuxfs4.tar.gz -C $ROOTFS_DIR
+  tar --xattrs --xattrs-include='*' -pzxf $ROOTFS_PACKAGE/cflinuxfs4.tar.gz -C $ROOTFS_DIR
 fi
 
 if grep -q "trusted_ca_certificates" $TRUSTED_CERT_FILE; then
@@ -46,5 +46,5 @@ fi
 # change modification time to invalidate garden's image cache
 touch $ROOTFS_DIR
 
-tar -C $ROOTFS_DIR -cf $ROOTFS_TAR .
+tar --xattrs --xattrs-include='*' -C $ROOTFS_DIR -cf $ROOTFS_TAR .
 rm -rf $ROOTFS_DIR


### PR DESCRIPTION
This bosh-release untars and retars the rootFS to update ca certs, but in the process did not preserve xattr information. #20 
This issue has already  #been committed to [cflinuxfs4-release](https://github.com/cloudfoundry/cflinuxfs4-release/pull/5).
